### PR TITLE
Create data-driven project framework

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,19 +68,28 @@
     @media (min-width: 680px) { .card { grid-column: span 6; } }
     @media (min-width: 980px) { .card { grid-column: span 4; } }
 
-    .frame { aspect-ratio: 16/9; background:
-        linear-gradient(100deg, rgba(255,255,255,.08), rgba(255,255,255,.18) 20%, rgba(255,255,255,.08) 40%)
+    .card-link { display: flex; flex-direction: column; text-decoration: none; color: inherit; height: 100%; }
+    .card-link:focus-visible { outline: 2px solid color-mix(in oklab, var(--accent), transparent 20%); outline-offset: 4px; }
+    .frame { position: relative; aspect-ratio: 16/9; background:
+        linear-gradient(120deg, rgba(255,255,255,.08), rgba(255,255,255,.16) 30%, rgba(255,255,255,.05) 60%)
         ,linear-gradient(180deg, var(--soft), color-mix(in oklab, var(--panel), transparent 12%));
-      background-size: 220% 100%, 100% 100%; border-bottom: 1px solid color-mix(in oklab, var(--muted), transparent 70%);
-      animation: shimmer 2.2s infinite; }
+      border-bottom: 1px solid color-mix(in oklab, var(--muted), transparent 70%); overflow: hidden; }
+    .frame img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .frame-placeholder { position: absolute; inset: 0; background:
+        linear-gradient(100deg, rgba(255,255,255,.12), rgba(255,255,255,.22) 35%, rgba(255,255,255,.10) 70%)
+        ,linear-gradient(180deg, var(--soft), color-mix(in oklab, var(--panel), transparent 12%));
+      background-size: 220% 100%, 100% 100%; animation: shimmer 2.2s infinite; }
     @keyframes shimmer { from { background-position: 200% 0, 0 0; } to { background-position: -20% 0, 0 0; } }
 
-    .card-body { padding: 14px 14px 16px; }
-    .card h3 { margin: 4px 0 6px; font-size: 18px; letter-spacing: -.01em; }
-    .card p { margin: 0 0 10px; color: var(--muted); font-size: 14px; }
+    .card-body { padding: 14px 14px 16px; display: flex; flex-direction: column; gap: 10px; flex: 1; }
+    .card-body h3 { margin: 4px 0 0; font-size: 18px; letter-spacing: -.01em; }
+    .card-body p { margin: 0; color: var(--muted); font-size: 14px; }
     .tags { display:flex; flex-wrap:wrap; gap:8px; }
     .tag { font-size: 12px; padding: 6px 10px; border:1px solid color-mix(in oklab, var(--muted), transparent 60%); border-radius: 999px; color: var(--muted); }
 
+    #projects-grid { min-height: 180px; }
+    .projects-status { margin: 12px 0 0; color: var(--muted); font-size: 13px; }
+    .projects-hint { margin: 10px 0 0; color: var(--muted); font-size: 13px; }
     /* ------- Footer ------- */
     footer { padding: 44px 0 64px; color: var(--muted); font-size: 14px; }
     footer .links { display:flex; gap:14px; flex-wrap:wrap; }
@@ -112,64 +121,13 @@
 
     <section id="projects">
       <div class="section-head">
-        <h2>Projects (placeholder)</h2>
-        <p>These cards are just empty frames + filler text — swap in real content anytime.</p>
+        <h2>Projects</h2>
+        <p>Manage cards from <code>projects/projects.json</code> and each entry will link to its own page.</p>
       </div>
 
-      <div class="grid">
-        <!-- Card 1 -->
-        <article class="card reveal">
-          <div class="frame" role="img" aria-label="Placeholder image frame"></div>
-          <div class="card-body">
-            <h3>Demo Project One</h3>
-            <p>A short, vibe-y sentence about something cool you might ship here.</p>
-            <div class="tags">
-              <span class="tag">JavaScript</span>
-              <span class="tag">UI</span>
-              <span class="tag">Placeholder</span>
-            </div>
-          </div>
-        </article>
-
-        <!-- Card 2 -->
-        <article class="card reveal">
-          <div class="frame" role="img" aria-label="Placeholder image frame"></div>
-          <div class="card-body">
-            <h3>Demo Project Two</h3>
-            <p>Room for a sentence about an AI experiment or interactive toy.</p>
-            <div class="tags">
-              <span class="tag">AI</span>
-              <span class="tag">Prototype</span>
-            </div>
-          </div>
-        </article>
-
-        <!-- Card 3 -->
-        <article class="card reveal">
-          <div class="frame" role="img" aria-label="Placeholder image frame"></div>
-          <div class="card-body">
-            <h3>Demo Project Three</h3>
-            <p>Drop in a GIF or screenshot later — for now this shimmers.</p>
-            <div class="tags">
-              <span class="tag">Performance</span>
-              <span class="tag">Accessibility</span>
-            </div>
-          </div>
-        </article>
-
-        <!-- Card 4 -->
-        <article class="card reveal">
-          <div class="frame" role="img" aria-label="Placeholder image frame"></div>
-          <div class="card-body">
-            <h3>Demo Project Four</h3>
-            <p>Another slot for whatever: datasets, viz, write-up, etc.</p>
-            <div class="tags">
-              <span class="tag">Data</span>
-              <span class="tag">Viz</span>
-            </div>
-          </div>
-        </article>
-      </div>
+      <div id="projects-grid" class="grid" aria-live="polite" aria-busy="true"></div>
+      <p id="projects-status" class="projects-status" role="status">Loading projects…</p>
+      <p class="projects-hint">Manage cards via <code>projects/projects.json</code>. Each entry links to its own standalone page.</p>
     </section>
 
     <section id="contact">
@@ -198,14 +156,76 @@
   </footer>
 
   <script>
-    // Year
-    document.getElementById('y').textContent = new Date().getFullYear();
+    const yearEl = document.getElementById('y');
+    if (yearEl) yearEl.textContent = new Date().getFullYear();
 
-    // Subtle scroll-reveal for cards
     const io = new IntersectionObserver((entries) => {
-      for (const e of entries) if (e.isIntersecting) e.target.classList.add('show');
+      for (const entry of entries) {
+        if (entry.isIntersecting) entry.target.classList.add('show');
+      }
     }, { threshold: 0.12 });
-    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+
+    function observeReveals(root = document) {
+      root.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+    }
+    observeReveals();
+
+    async function loadProjects() {
+      const grid = document.getElementById('projects-grid');
+      const status = document.getElementById('projects-status');
+      if (!grid) return;
+      grid.setAttribute('aria-busy', 'true');
+      if (status) {
+        status.textContent = 'Loading projects…';
+        status.hidden = false;
+      }
+
+      try {
+        const res = await fetch('projects/projects.json', { cache: 'no-cache' });
+        if (!res.ok) throw new Error('Request failed');
+        const projects = await res.json();
+        grid.innerHTML = '';
+
+        projects.forEach((project) => {
+          const article = document.createElement('article');
+          article.className = 'card reveal';
+          const tags = (project.tags || []).map((tag) => `<span class="tag">${tag}</span>`).join('');
+          article.innerHTML = `
+            <a class="card-link" href="${project.url || '#'}">
+              <div class="frame">
+                ${project.previewImage ? `<img src="${project.previewImage}" alt="${project.previewAlt || project.title}" loading="lazy">` : '<span class="frame-placeholder" aria-hidden="true"></span>'}
+              </div>
+              <div class="card-body">
+                <h3>${project.title}</h3>
+                <p>${project.summary || ''}</p>
+                <div class="tags">${tags}</div>
+              </div>
+            </a>
+          `;
+          grid.appendChild(article);
+          io.observe(article);
+        });
+
+        if (!grid.children.length) {
+          if (status) {
+            status.textContent = 'No projects yet. Add entries to projects/projects.json to populate this grid.';
+            status.hidden = false;
+          }
+        } else if (status) {
+          status.hidden = true;
+        }
+      } catch (err) {
+        grid.innerHTML = '';
+        if (status) {
+          status.textContent = 'Unable to load projects. Double-check projects/projects.json.';
+          status.hidden = false;
+        }
+      } finally {
+        grid.setAttribute('aria-busy', 'false');
+      }
+    }
+
+    loadProjects();
   </script>
 </body>
 </html>

--- a/projects/ai-model-evaluation-systems-diagram/index.html
+++ b/projects/ai-model-evaluation-systems-diagram/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AI Model Evaluation Systems Diagram — Nick Young</title>
+  <meta name="description" content="Interactive React component that visualizes an AI model evaluation workflow with tooltips and simulation states." />
+  <link rel="stylesheet" href="../project.css" />
+</head>
+<body>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="../../index.html">← Back to projects</a>
+    <span> / AI Model Evaluation Systems Diagram</span>
+  </nav>
+
+  <header>
+    <div class="hero" role="presentation">
+      <h1>AI Model Evaluation Systems Diagram</h1>
+      <p>
+        A single-file React component that renders an interactive SVG flowchart for comparing and auditing model evaluation
+        pipelines. Tooltips, simulation highlights, and responsive layout are all included with zero external UI dependencies.
+      </p>
+      <div class="button-row">
+        <a class="button" href="../../ai_model_evaluation_systems_diagram" download>Download component</a>
+        <a class="button" href="#code">Jump to source</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <figure>
+        <img src="preview.svg" alt="Stylized preview of the AI evaluation system diagram" loading="lazy" />
+      </figure>
+      <div class="tag-row">
+        <span class="tag">React</span>
+        <span class="tag">SVG</span>
+        <span class="tag">Tooling</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>What&apos;s inside</h2>
+      <p>
+        The component organizes evaluation stages into reusable node definitions and wiring logic, then renders an SVG with
+        animated highlights. It exposes a lightweight simulation runner for demos and leans on CSS utilities instead of
+        external frameworks, keeping bundle size low.
+      </p>
+      <p>
+        Drop it into any React setup (Vite, Next.js, Create React App) and it will render a polished diagram immediately. The
+        component is intentionally self-contained, so you can adapt node definitions, colors, or tooltip copy without chasing
+        extra files.
+      </p>
+    </section>
+
+    <section id="code">
+      <h2>Source</h2>
+      <p>
+        The latest version lives alongside this page. Copy it straight from the snippet below or download it if you prefer to
+        wire it into your build pipeline manually.
+      </p>
+      <pre><code id="code-block">Loading component…</code></pre>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="y"></span> Nick Young. Crafted for rapid prototyping and demos.</p>
+  </footer>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    async function loadSource() {
+      const el = document.getElementById('code-block');
+      try {
+        const res = await fetch('../../ai_model_evaluation_systems_diagram');
+        if (!res.ok) throw new Error('Request failed');
+        const text = await res.text();
+        el.textContent = text;
+      } catch (err) {
+        el.textContent = 'Unable to load source. Try downloading the file instead.';
+      }
+    }
+    loadSource();
+  </script>
+</body>
+</html>

--- a/projects/ai-model-evaluation-systems-diagram/preview.svg
+++ b/projects/ai-model-evaluation-systems-diagram/preview.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="Stylized AI evaluation system diagram">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#131622" />
+      <stop offset="100%" stop-color="#1b233a" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7c5cff" />
+      <stop offset="100%" stop-color="#00e5ff" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)" />
+  <g fill="#1f2a4a" stroke="#334064" stroke-width="2" stroke-linejoin="round">
+    <rect x="48" y="48" width="140" height="64" rx="14" />
+    <rect x="220" y="48" width="170" height="64" rx="14" />
+    <rect x="420" y="48" width="170" height="64" rx="14" />
+    <rect x="120" y="156" width="120" height="56" rx="12" />
+    <rect x="264" y="156" width="120" height="56" rx="12" />
+    <rect x="408" y="156" width="120" height="56" rx="12" />
+    <rect x="552" y="156" width="120" height="56" rx="12" />
+    <rect x="300" y="248" width="180" height="60" rx="16" />
+  </g>
+  <g stroke="url(#accent)" stroke-width="4" stroke-linecap="round" opacity="0.9">
+    <path d="M188 80h24" />
+    <path d="M390 80h24" />
+    <path d="M505 112v36" />
+    <path d="M180 212l120 36" />
+    <path d="M324 212l90 36" />
+    <path d="M468 212l-24 36" />
+  </g>
+  <text x="68" y="88" fill="#8aa0ff" font-family="Inter, sans-serif" font-size="18" font-weight="600">Inputs</text>
+  <text x="235" y="88" fill="#8aa0ff" font-family="Inter, sans-serif" font-size="18" font-weight="600">Preprocess</text>
+  <text x="441" y="88" fill="#8aa0ff" font-family="Inter, sans-serif" font-size="18" font-weight="600">Distributor</text>
+  <text x="138" y="190" fill="#9bb6ff" font-family="Inter, sans-serif" font-size="14">Model A</text>
+  <text x="284" y="190" fill="#9bb6ff" font-family="Inter, sans-serif" font-size="14">Model B</text>
+  <text x="428" y="190" fill="#9bb6ff" font-family="Inter, sans-serif" font-size="14">Model C</text>
+  <text x="572" y="190" fill="#9bb6ff" font-family="Inter, sans-serif" font-size="14">Model D</text>
+  <text x="332" y="284" fill="#9bb6ff" font-family="Inter, sans-serif" font-size="16">Overseer &amp; Metrics</text>
+  <text x="48" y="320" fill="#7c8ba6" font-family="Inter, sans-serif" font-size="16">Flowchart preview</text>
+</svg>

--- a/projects/demo-project-one/index.html
+++ b/projects/demo-project-one/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Demo Project One — Nick Young</title>
+  <meta name="description" content="Placeholder case study describing a concept UI prototype." />
+  <link rel="stylesheet" href="../project.css" />
+</head>
+<body>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="../../index.html">← Back to projects</a>
+    <span> / Demo Project One</span>
+  </nav>
+
+  <header>
+    <div class="hero" role="presentation">
+      <h1>Demo Project One</h1>
+      <p>
+        A concept UI sprint exploring onboarding flows for a data-heavy analytics platform. This placeholder write-up gives you
+        a sense of how project pages can be structured.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <figure>
+        <img src="preview.svg" alt="Concept UI mock preview" loading="lazy" />
+      </figure>
+      <div class="tag-row">
+        <span class="tag">Product Design</span>
+        <span class="tag">Prototype</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Quick summary</h2>
+      <p>
+        Swap this content with your own notes, release metrics, or feature call-outs. Each project page can host its own assets
+        (images, downloads, embeds) inside the folder without touching the homepage layout.
+      </p>
+      <p>
+        Keep the tone brief but informative, highlight the problem you solved, and link out to live demos or GitHub repos as
+        needed.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="y"></span> Nick Young. This is placeholder text for a future case study.</p>
+  </footer>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/projects/demo-project-one/preview.svg
+++ b/projects/demo-project-one/preview.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="UI prototype preview">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2b163d" />
+      <stop offset="100%" stop-color="#1c1f5b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)" />
+  <g fill="#ffffff" opacity="0.1">
+    <rect x="80" y="72" width="160" height="64" rx="14" />
+    <rect x="264" y="72" width="120" height="64" rx="14" />
+    <rect x="408" y="72" width="152" height="64" rx="14" />
+    <rect x="80" y="160" width="200" height="160" rx="18" />
+    <rect x="304" y="160" width="256" height="72" rx="18" />
+    <rect x="304" y="252" width="256" height="68" rx="18" />
+  </g>
+  <text x="80" y="320" fill="#f6e9ff" font-family="Inter, sans-serif" font-size="18" font-weight="600">Concept UI mock</text>
+</svg>

--- a/projects/demo-project-three/index.html
+++ b/projects/demo-project-three/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Demo Project Three — Nick Young</title>
+  <meta name="description" content="Placeholder project page for a data storytelling experiment." />
+  <link rel="stylesheet" href="../project.css" />
+</head>
+<body>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="../../index.html">← Back to projects</a>
+    <span> / Demo Project Three</span>
+  </nav>
+
+  <header>
+    <div class="hero" role="presentation">
+      <h1>Demo Project Three</h1>
+      <p>
+        A data storytelling exploration that pairs motion with lightweight editorial copy. Replace this text with a real
+        narrative once you are ready.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <figure>
+        <img src="preview.svg" alt="Data narrative preview" loading="lazy" />
+      </figure>
+      <div class="tag-row">
+        <span class="tag">Storytelling</span>
+        <span class="tag">Data Viz</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Next steps</h2>
+      <p>
+        Create as many pages like this as you need. The homepage cards will automatically link to the files listed in the JSON
+        definition, so the portfolio stays organized even as it grows.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="y"></span> Nick Young. Placeholder narrative coming soon.</p>
+  </footer>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/projects/demo-project-three/preview.svg
+++ b/projects/demo-project-three/preview.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="Data storytelling preview">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c2216" />
+      <stop offset="100%" stop-color="#233d1c" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)" />
+  <polyline points="60,260 160,200 240,230 320,150 420,200 520,120 580,150" fill="none" stroke="#9be26d" stroke-width="6" stroke-linejoin="round" />
+  <rect x="420" y="60" width="160" height="90" rx="16" fill="#2f4d25" stroke="#4f7e3d" stroke-width="3" />
+  <text x="440" y="110" fill="#c8ffc3" font-family="Inter, sans-serif" font-size="20" font-weight="600">Story beat</text>
+  <text x="60" y="320" fill="#cfe8b8" font-family="Inter, sans-serif" font-size="18" font-weight="600">Data narrative</text>
+</svg>

--- a/projects/demo-project-two/index.html
+++ b/projects/demo-project-two/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Demo Project Two — Nick Young</title>
+  <meta name="description" content="Placeholder write-up for an AI experimentation platform." />
+  <link rel="stylesheet" href="../project.css" />
+</head>
+<body>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="../../index.html">← Back to projects</a>
+    <span> / Demo Project Two</span>
+  </nav>
+
+  <header>
+    <div class="hero" role="presentation">
+      <h1>Demo Project Two</h1>
+      <p>
+        A sandbox for comparing prompts and agents across multiple large language models. Use this slot for high-level context
+        and any quick stats you want to feature.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <figure>
+        <img src="preview.svg" alt="Multi-model experiment preview" loading="lazy" />
+      </figure>
+      <div class="tag-row">
+        <span class="tag">AI</span>
+        <span class="tag">Tooling</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>How to customize</h2>
+      <p>
+        Duplicate this page, swap the copy, and drop in your own imagery. The global JSON file drives the homepage grid so you
+        can re-order or remove entries without touching any markup.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="y"></span> Nick Young. Another placeholder project waiting for your story.</p>
+  </footer>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/projects/demo-project-two/preview.svg
+++ b/projects/demo-project-two/preview.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-label="AI experiment preview">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f2a3a" />
+      <stop offset="100%" stop-color="#12395a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)" />
+  <g stroke="#49c6ff" stroke-width="3" fill="none" opacity="0.7">
+    <circle cx="160" cy="160" r="70" />
+    <circle cx="320" cy="220" r="90" />
+    <circle cx="460" cy="140" r="60" />
+  </g>
+  <g fill="#49c6ff" opacity="0.9">
+    <circle cx="200" cy="120" r="6" />
+    <circle cx="280" cy="280" r="6" />
+    <circle cx="440" cy="200" r="6" />
+  </g>
+  <text x="64" y="320" fill="#c1ecff" font-family="Inter, sans-serif" font-size="18" font-weight="600">Multi-model testbed</text>
+</svg>

--- a/projects/project.css
+++ b/projects/project.css
@@ -1,0 +1,152 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0b0c10;
+  --panel: #12141a;
+  --soft: #1a1d26;
+  --fg: #e6e8ee;
+  --muted: #a1a6b3;
+  --accent: #7c5cff;
+  --accent-2: #00e5ff;
+  --radius: 18px;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f7f7fb;
+    --panel: #ffffff;
+    --soft: #f1f3f9;
+    --fg: #0c0e12;
+    --muted: #5c6472;
+  }
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: ui-sans-serif, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, system-ui, sans-serif;
+  background: radial-gradient(1200px 600px at 80% -10%, rgba(124, 92, 255, 0.15), transparent 60%),
+    radial-gradient(800px 500px at -10% 20%, rgba(0, 229, 255, 0.1), transparent 60%),
+    var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+header {
+  padding: 28px 0 10px;
+}
+main {
+  width: min(900px, 92vw);
+  margin: 0 auto;
+  flex: 1;
+  padding-bottom: 64px;
+}
+.footer {
+  width: min(900px, 92vw);
+  margin: 0 auto 48px;
+  color: var(--muted);
+  font-size: 14px;
+}
+nav a,
+.breadcrumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+nav a:hover,
+.breadcrumb a:hover {
+  color: var(--fg);
+}
+.hero {
+  background: linear-gradient(180deg, color-mix(in oklab, var(--panel), transparent 10%), color-mix(in oklab, var(--panel), transparent 35%));
+  padding: 32px clamp(20px, 5vw, 42px);
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 70%);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.22);
+}
+.hero h1 {
+  margin: 0 0 12px;
+  font-size: clamp(32px, 6vw, 48px);
+}
+.hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(16px, 2.4vw, 18px);
+}
+section {
+  margin-top: 42px;
+  background: color-mix(in oklab, var(--panel), transparent 20%);
+  padding: clamp(20px, 4vw, 36px);
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 75%);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+section h2 {
+  margin-top: 0;
+}
+section p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 60%);
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 14px;
+}
+.button:hover {
+  border-color: color-mix(in oklab, var(--muted), transparent 40%);
+}
+pre {
+  background: color-mix(in oklab, var(--panel), transparent 30%);
+  padding: 18px;
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 70%);
+  font-size: 13px;
+  line-height: 1.55;
+}
+code {
+  font-family: "SFMono-Regular", ui-monospace, "SFMono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+figure {
+  margin: 0;
+}
+figure img {
+  max-width: 100%;
+  border-radius: 14px;
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 70%);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.24);
+}
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+.tag {
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--muted), transparent 60%);
+  color: var(--muted);
+}
+.breadcrumb {
+  width: min(900px, 92vw);
+  margin: 0 auto;
+  font-size: 14px;
+  color: var(--muted);
+}
+.breadcrumb span {
+  color: var(--fg);
+}

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -1,0 +1,38 @@
+[
+  {
+    "slug": "ai-model-evaluation-systems-diagram",
+    "title": "AI Model Evaluation Systems Diagram",
+    "summary": "Interactive React flowchart that visualizes an AI evaluation pipeline with tooltips and a mini simulation.",
+    "tags": ["React", "SVG", "Tooling"],
+    "url": "projects/ai-model-evaluation-systems-diagram/",
+    "previewImage": "projects/ai-model-evaluation-systems-diagram/preview.svg",
+    "previewAlt": "Stylized AI evaluation system diagram"
+  },
+  {
+    "slug": "demo-project-one",
+    "title": "Demo Project One",
+    "summary": "Concept UI sprint exploring onboarding and data summarization flows for an analytics app.",
+    "tags": ["Product Design", "Prototype"],
+    "url": "projects/demo-project-one/",
+    "previewImage": "projects/demo-project-one/preview.svg",
+    "previewAlt": "Concept UI mock"
+  },
+  {
+    "slug": "demo-project-two",
+    "title": "Demo Project Two",
+    "summary": "Placeholder AI experimentation hub for testing prompts across several language models.",
+    "tags": ["AI", "Tooling"],
+    "url": "projects/demo-project-two/",
+    "previewImage": "projects/demo-project-two/preview.svg",
+    "previewAlt": "Abstract AI experiment art"
+  },
+  {
+    "slug": "demo-project-three",
+    "title": "Demo Project Three",
+    "summary": "Data storytelling exercise combining light motion with an editorial narrative.",
+    "tags": ["Storytelling", "Data Viz"],
+    "url": "projects/demo-project-three/",
+    "previewImage": "projects/demo-project-three/preview.svg",
+    "previewAlt": "Data narrative illustration"
+  }
+]


### PR DESCRIPTION
## Summary
- replace the hard-coded project cards with a data-driven renderer that reads from `projects/projects.json`
- add dedicated project pages (including the AI Model Evaluation Systems Diagram first) that share reusable styling and assets
- supply preview artwork and shared styles to make adding, reordering, or removing projects straightforward

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68f5c9dfbc74832ba7f33cd5d542be68