### PR TITLE
Document portfolio architecture and content model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
 # PortfolioSite
-Personal portfolio website for displaying project progress and tools.
+
+Lightweight static portfolio built with semantic HTML, inline CSS, and a single script. The site showcases featured work and a chronological project timeline sourced from `projects/projects.json`.
+
+## Quick start
+
+You only need a static file server to preview the site locally.
+
+1. Install any static server if you do not already have one (for example `npm install -g serve`).
+2. From the repository root, start the server: `npx serve .` (or `python -m http.server 8787`).
+3. Visit the reported URL (usually `http://localhost:3000` or `http://localhost:8787`).
+4. Update content (project JSON or HTML) and refresh to see changes.
+
+> **Cloudflare Pages:** `wrangler.json` is preconfigured so `wrangler pages dev` will serve the exact same assets the production deployment expects.
+
+## Repository layout
+
+| Path | Purpose |
+| --- | --- |
+| `index.html` | Homepage with inline styles, render logic for featured project + timeline, and IntersectionObserver animations. |
+| `projects/projects.json` | Canonical data source for featured project selection and the project timeline. Most recent `date` values should appear first. |
+| `projects/*/index.html` | Individual project write-ups. Each folder owns its assets (SVGs, downloads, etc.). |
+| `projects/project.css` | Shared styles for project detail pages (hero, layout, typography). |
+| `docs/` | Extended documentation describing architecture, content models, and maintenance tasks. |
+| `wrangler.json` | Cloudflare Pages configuration pointing at the repo root for assets. |
+
+Review `AGENTS.md` files (in the repo root and inside `projects/`) before editing; they outline coding conventions and data requirements.
+
+## Content model
+
+Project metadata is stored in `projects/projects.json` and consumed by the homepage script.
+
+Required fields per entry:
+
+- `slug`: Unique identifier matching the detail page folder name.
+- `title`: Project name displayed throughout the site.
+- `summary`: Short description used in the timeline and featured card.
+- `tags`: Array of short skill or category strings.
+- `url`: Relative link to the detail page (`projects/<slug>/`).
+- `previewImage`: Path to a thumbnail or SVG preview.
+- `previewAlt`: Accessible alt text for the preview image.
+- `date`: ISO 8601 date string (e.g., `"2024-07-15"`).
+- Optional `featured: true` flags the homepage to highlight that project. Only one entry should use it at a time.
+
+The homepage sorts projects by `date` (newest first) and gracefully handles missing or invalid dates by showing "Undated". Missing preview assets or tags simply render blank areas.
+
+## Homepage architecture (`index.html`)
+
+`index.html` contains the entire landing page experience:
+
+- **Header / Intro**: Sticky navigation with anchors to page sections. Branding text can be edited inline.
+- **Featured Project Section**: Empty container populated by `renderFeatured` after fetching `projects.json`.
+- **Project Timeline**: `<article>` cards are created via `createTimelineItem` with reveal + active animations managed by an `IntersectionObserver` (`timelineObserver`).
+- **Contact Section**: Static placeholder content using the same card styling as timeline items.
+- **Footer**: Static links and copyright text. The current year is injected via the script (`yearEl`).
+
+All motion hooks (`observeReveals` + `timelineObserver`) gracefully no-op if JavaScript is unavailable. Status elements (`aria-busy` + `role="status"`) provide loading/error messaging for screen readers.
+
+## Project detail pages
+
+Each project lives in `projects/<slug>/` with:
+
+- `index.html`: The long-form write-up or interactive demo.
+- Supporting assets (SVG previews, downloads, etc.).
+
+Pages share a consistent layout and theming via `projects/project.css`. When building a new project page:
+
+1. Copy an existing project folder as a template.
+2. Update `<title>`, hero content, and body sections.
+3. Adjust links (e.g., downloads) to match the new slug.
+4. Add or replace preview assets in the same folder.
+5. Ensure the entry exists in `projects/projects.json` with matching `slug`, `url`, and `previewImage` paths.
+
+The AI Model Evaluation Systems Diagram page additionally loads React + Babel from CDNs for the embedded demo. That setup is self-contained—no build steps are required.
+
+## Styling tokens
+
+The homepage relies on CSS custom properties defined in the `:root` block inside `index.html`. Project detail pages consume a similar palette via `projects/project.css`. Introduce new tokens sparingly, keep naming descriptive, and document their purpose when added.
+
+## Deployment & maintenance
+
+- **Deployment**: Upload the repository to Cloudflare Pages (or any static host). The entire build is static files.
+- **Content updates**: Modify JSON or HTML as needed. Keep `projects.json` sorted by `date` descending to preserve chronological order.
+- **Accessibility**: When editing markup, maintain ARIA roles and status messaging for loading states.
+- **Documentation**: See `docs/ARCHITECTURE.md` for deep dives into each module and maintenance checklists.
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# PortfolioSite architecture & maintenance guide
+
+This document maps the portfolio to help contributors (and automation) locate the right files quickly. Every section is self-contained so content can be swapped or reorganized without disturbing the rest of the site.
+
+## High-level flow
+
+1. A visitor loads `index.html`.
+2. Inline JavaScript fetches `projects/projects.json` to gather project metadata.
+3. The script renders:
+   - A featured card for the single `featured: true` entry (if present).
+   - A chronological timeline of projects sorted by `date`.
+4. IntersectionObservers animate the timeline as items enter the viewport.
+5. Detail pages under `projects/<slug>/` deliver long-form content or demos.
+
+Everything ships as static assets—no runtime build step is required.
+
+## Homepage modules (`index.html`)
+
+`index.html` is organized into clearly separated blocks:
+
+| Block | Selector/ID | Purpose | Dependencies |
+| --- | --- | --- | --- |
+| Header & navigation | `<header>` / `.nav` | Sticky navigation with in-page anchors. | None. |
+| Intro | `#intro` | Hero headline + CTA linking to featured section. | None. |
+| Featured project | `#featured` with `#featured-project` container | Filled by `renderFeatured(project)` once JSON loads. | Requires one entry with `featured: true`. |
+| Timeline | `#projects` with `#project-timeline` container | Populated by `createTimelineItem(project)` for each project. | Needs `projects/projects.json`. |
+| Contact | `#contact` | Static card, styled like timeline entries. | None. |
+| Footer | `<footer>` | Static resource links and dynamic year. | Script updates `#y`. |
+
+### Script structure
+
+The script at the bottom of `index.html` is broken into small, reusable functions:
+
+- `observeReveals(root)` wires up `.reveal` elements to a generic IntersectionObserver for fade-in effects. It accepts any DOM node so you can reuse it when injecting new markup.
+- `timelineObserver` toggles `.active` on timeline items, powering the expand/contract animation.
+- `formatProjectDate(value)` centralizes date formatting; it already guards against invalid input.
+- `createTagList(tags)` converts an array of tag strings into badge markup.
+- `renderFeatured(project)` handles empty state messaging, ARIA attributes, and the DOM structure for the featured card.
+- `createTimelineItem(project)` returns a fully wired timeline `<article>` with reveal classes.
+- `loadProjects()` orchestrates fetch, error handling, DOM updates, and accessibility status flags.
+
+When adding new sections, use the same pattern: create a dedicated container, a `render*` function that only touches that container, and keep error/status messaging separate.
+
+### Accessibility contracts
+
+- Loading messages live inside elements with `role="status"` (`#featured-status`, `#projects-status`). Update these strings if you rename sections.
+- `aria-busy` is applied before/after fetches. Maintain this contract if you change the data flow.
+- Decorative animations rely on `IntersectionObserver`; the layout still renders cleanly without JavaScript.
+
+## Project metadata (`projects/projects.json`)
+
+- Sorted newest-to-oldest by `date`. Keep the file ordered manually.
+- Only one project should have `"featured": true`. The script picks the first match if multiple exist.
+- Optional keys may be added, but document them in `projects/AGENTS.md` and update this section.
+- The homepage treats missing fields gracefully, but incomplete entries will show blank spaces. Validate before publishing.
+
+### Adding a project
+
+1. Create `projects/<slug>/` and copy an existing `index.html` as a starting point.
+2. Add assets (preview SVGs, downloads) alongside the HTML.
+3. Update `projects/projects.json` with the new entry—ensure `url` points to `projects/<slug>/` and `previewImage` references a file inside the folder.
+4. Set `featured: true` if the project should appear in the featured slot (and remove that flag from any other entry).
+5. Load the site locally to confirm the featured card, timeline ordering, and alt text all look correct.
+
+## Project detail templates (`projects/*/index.html`)
+
+All project pages:
+
+- Link to the shared stylesheet `../project.css` for consistent styling.
+- Start with a breadcrumb navigation pointing back to the homepage.
+- Contain a `.hero` section describing the work and linking to resources.
+- Use `<section>` blocks for modular content areas (demo, screenshots, write-up, etc.).
+- Conclude with the shared footer markup, which reuses the dynamic year script from the homepage.
+
+Project folders are independent. You can replace one folder entirely without affecting the rest of the site as long as `projects.json` references remain valid.
+
+## Shared stylesheet (`projects/project.css`)
+
+Defines the color palette, layout helpers, and button styles for project pages. If you need new utility classes:
+
+1. Add them here with descriptive names.
+2. Ensure they degrade gracefully in light/dark modes.
+3. Document the addition (update this section or the README).
+
+Avoid duplicating styles inside individual project pages unless a component is truly unique.
+
+## Deployment
+
+- **Cloudflare Pages**: Use `wrangler pages deploy` or connect the GitHub repository directly. `wrangler.json` already points to the repo root as the asset directory.
+- **Other static hosts**: Upload the repository contents as-is; no build step is required.
+- **Local verification**: `npx serve .` or `python -m http.server 8787` from the repo root serves the site for sanity checks.
+
+## Maintenance checklist
+
+- [ ] Confirm `projects/projects.json` remains sorted by descending date.
+- [ ] Verify only one project is flagged as `featured`.
+- [ ] Ensure new project folders include a preview asset referenced in JSON.
+- [ ] Review ARIA/status text when editing sections to keep assistive messaging accurate.
+- [ ] Update documentation if you introduce new sections, tokens, or data fields.
+


### PR DESCRIPTION
## Summary
- expand the README with quick-start steps, repository map, and guidance for editing project metadata and pages
- add an architecture guide detailing homepage modules, script responsibilities, and project maintenance checklists

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f5db8a2b6c832baca7939b3e7ced4b