### PR TITLE
Adjust hero spacing to hint at featured project

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,12 +46,12 @@
     .nav a { color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; }
     .nav a:hover { color: var(--fg); }
 
-    .intro { padding: clamp(56px, 6vw, 100px) 0 32px; display: grid; gap: clamp(32px, 5vw, 48px); }
-    .intro h1 { font-size: clamp(40px, 7vw, 72px); line-height: 1.05; margin: 0 0 14px; letter-spacing: -0.02em; }
+    .intro { padding: clamp(52px, 5.5vw, 92px) 0 clamp(14px, 3vh, 24px); display: grid; gap: clamp(30px, 4.5vw, 44px); }
+    .intro h1 { font-size: clamp(36px, 6.5vw, 64px); line-height: 1.05; margin: 0 0 14px; letter-spacing: -0.02em; }
     .intro h1 .accent { background: linear-gradient(90deg, var(--accent), var(--accent-2)); -webkit-background-clip: text; background-clip: text; color: transparent; }
     .intro p { margin: 0; color: var(--muted); font-size: clamp(16px, 2vw, 18px); max-width: 560px; }
-    .intro-card { background: linear-gradient(160deg, color-mix(in oklab, var(--soft), transparent 0%), color-mix(in oklab, var(--panel), transparent 0%)); border-radius: calc(var(--radius) + 2px); border: 1px solid color-mix(in oklab, var(--muted), transparent 55%); box-shadow: var(--shadow); padding: clamp(18px, 3vw, 26px); display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr); gap: clamp(18px, 3vw, 28px); }
-    .intro-pane { background: color-mix(in oklab, var(--soft), transparent 0%); border: 1px solid color-mix(in oklab, var(--muted), transparent 70%); border-radius: calc(var(--radius) - 4px); padding: 16px 18px; display: flex; flex-direction: column; gap: 10px; }
+    .intro-card { background: linear-gradient(160deg, color-mix(in oklab, var(--soft), transparent 0%), color-mix(in oklab, var(--panel), transparent 0%)); border-radius: calc(var(--radius) + 2px); border: 1px solid color-mix(in oklab, var(--muted), transparent 55%); box-shadow: var(--shadow); padding: clamp(16px, 2.6vw, 22px); display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr); gap: clamp(16px, 2.8vw, 24px); }
+    .intro-pane { background: color-mix(in oklab, var(--soft), transparent 0%); border: 1px solid color-mix(in oklab, var(--muted), transparent 70%); border-radius: calc(var(--radius) - 4px); padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
     .intro-pane h2 { margin: 0; font-size: 18px; letter-spacing: -0.01em; }
     .intro-pane .subtitle { color: var(--muted); margin: 0; font-size: 14px; }
     .intro-pane .divider { height: 1px; background: color-mix(in oklab, var(--muted), transparent 72%); margin: 10px 0; border-radius: 999px; }


### PR DESCRIPTION
## Summary
- shrink the hero heading and intro card padding so the landing panel reads lighter
- trim vertical spacing around the intro section to let the featured project peek into view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5f79c9528832b9a941f192d56629c