### PR TITLE
Remove initial question from intro animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,22 +357,14 @@
       const sequences = [
         [
           {
-            role: 'you',
-            text: "How many R's are there in strawberry?",
+            role: 'ai',
+            text: 'Seven.',
             delayBefore: 2000,
-            type: true,
-            loadingIndicator: 'cursor',
-            loadingDuration: 1200,
+            loadingIndicator: 'dots',
+            loadingDuration: 900,
             onTypedComplete: () => {
               title.textContent = headingStates.contrast;
             }
-          },
-          {
-            role: 'ai',
-            text: 'Seven.',
-            delayBefore: 600,
-            loadingIndicator: 'dots',
-            loadingDuration: 900
           }
         ],
         [


### PR DESCRIPTION
## Summary
- remove the opening user prompt from the intro chat animation so the sequence no longer repeats the first question
- move the heading swap to the AI response to preserve the title change without the initial prompt

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f603792f38832b9ebd9636007f3f8d