### PR TITLE
Simplify AI evaluation project page layout

### DIFF
--- a/projects/ai-model-evaluation-systems-diagram/index.html
+++ b/projects/ai-model-evaluation-systems-diagram/index.html
@@ -20,16 +20,12 @@
         A single-file React component that renders an interactive SVG flowchart for comparing and auditing model evaluation
         pipelines. Tooltips, simulation highlights, and responsive layout are all included with zero external UI dependencies.
       </p>
-      <div class="button-row">
-        <a class="button" href="../../ai_model_evaluation_systems_diagram" download>Download component</a>
-        <a class="button" href="#code">Jump to source</a>
-      </div>
     </div>
   </header>
 
   <main>
     <section class="live-demo">
-      <h2>Interactive preview</h2>
+      <h2>Systems Diagram</h2>
       <p>
         Explore the working diagram below. Run the simulation to see how requests move through the evaluation stack,
         surface tooltips for each block, and compare randomized accuracy scores across models in real time.
@@ -48,29 +44,6 @@
         <span class="tag">SVG</span>
         <span class="tag">Tooling</span>
       </div>
-    </section>
-
-    <section>
-      <h2>What&apos;s inside</h2>
-      <p>
-        The component organizes evaluation stages into reusable node definitions and wiring logic, then renders an SVG with
-        animated highlights. It exposes a lightweight simulation runner for demos and leans on CSS utilities instead of
-        external frameworks, keeping bundle size low.
-      </p>
-      <p>
-        Drop it into any React setup (Vite, Next.js, Create React App) and it will render a polished diagram immediately. The
-        component is intentionally self-contained, so you can adapt node definitions, colors, or tooltip copy without chasing
-        extra files.
-      </p>
-    </section>
-
-    <section id="code">
-      <h2>Source</h2>
-      <p>
-        The latest version lives alongside this page. Copy it straight from the snippet below or download it if you prefer to
-        wire it into your build pipeline manually.
-      </p>
-      <pre><code id="code-block">Loading component…</code></pre>
     </section>
   </main>
 
@@ -540,19 +513,6 @@
   </script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
-
-    async function loadSource() {
-      const el = document.getElementById('code-block');
-      try {
-        const res = await fetch('../../ai_model_evaluation_systems_diagram');
-        if (!res.ok) throw new Error('Request failed');
-        const text = await res.text();
-        el.textContent = text;
-      } catch (err) {
-        el.textContent = 'Unable to load source. Try downloading the file instead.';
-      }
-    }
-    loadSource();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove download/source controls and supporting code from the AI Model Evaluation Systems page
- drop the "What's inside" and "Source" sections to streamline the layout
- retitle the interactive demo section to "Systems Diagram"

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f6045301d0832b968593939479e7b3