### PR TITLE
Add timeline preview imagery and project metadata checklist

### DIFF
--- a/docs/PROJECT_METADATA_GUIDE.md
+++ b/docs/PROJECT_METADATA_GUIDE.md
@@ -1,0 +1,14 @@
+# Project Metadata Checklist
+
+To appear correctly in the portfolio's featured project module and the project timeline, each entry in `projects/projects.json` should include the following fields:
+
+- **slug**: Unique identifier used for URLs and internal lookups.
+- **title**: Human-friendly project name shown in cards and headings.
+- **summary**: Short description that appears in the timeline previews.
+- **date**: ISO 8601 date string (e.g., `2024-10-05`) used for chronological sorting and display.
+- **previewImage**: Path to the preview illustration or screenshot shown in featured and timeline cards.
+- **previewAlt**: Descriptive alt text for the preview image, keeping the experience accessible.
+- **tags**: Array of quick descriptors that surface in the detailed timeline view.
+- **url**: Link to the project detail page or external case study.
+
+Optional fields should be documented in `projects/AGENTS.md` before use. Keeping this checklist complete ensures new projects slot into the site without layout or accessibility regressions.

--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
       padding: clamp(18px, 2.2vw, 24px);
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: clamp(14px, 2vw, 18px);
       opacity: 0;
       transform: translateY(14px) scale(.97);
       transition: opacity .32s ease, transform .32s ease;
@@ -271,6 +271,27 @@
       opacity: 1;
       transform: translateY(0) scale(1);
       pointer-events: auto;
+    }
+    .timeline-preview-media {
+      position: relative;
+      border-radius: calc(var(--radius) - 6px);
+      overflow: hidden;
+      aspect-ratio: 16/9;
+      border: 1px solid color-mix(in oklab, var(--muted), transparent 70%);
+      background: linear-gradient(120deg, rgba(255,255,255,.08), rgba(255,255,255,.16) 30%, rgba(255,255,255,.05) 60%),
+                  linear-gradient(180deg, var(--soft), color-mix(in oklab, var(--panel), transparent 12%));
+    }
+    .timeline-preview-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .timeline-preview-content {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      flex: 1;
     }
     .timeline-preview h3 {
       margin: 0;
@@ -776,18 +797,24 @@
         <div class="timeline-window">
           <a class="timeline-card" href="${project.url || '#'}">
             <div class="timeline-preview timeline-preview-small" data-preview="small" aria-hidden="false">
-              <h3>${project.title}</h3>
-              <p>${project.summary || ''}</p>
+              ${project.previewImage ? `<div class="timeline-preview-media"><img src="${project.previewImage}" alt="${project.previewAlt || project.title}" loading="lazy"></div>` : ''}
+              <div class="timeline-preview-content">
+                <h3>${project.title}</h3>
+                <p>${project.summary || ''}</p>
+              </div>
             </div>
             <div class="timeline-preview timeline-preview-large" data-preview="large" aria-hidden="true">
-              <div class="timeline-preview-meta">
-                <span>${tagSummary}</span>
-                <span>${formattedDate}</span>
+              ${project.previewImage ? `<div class="timeline-preview-media"><img src="${project.previewImage}" alt="${project.previewAlt || project.title}" loading="lazy"></div>` : ''}
+              <div class="timeline-preview-content">
+                <div class="timeline-preview-meta">
+                  <span>${tagSummary}</span>
+                  <span>${formattedDate}</span>
+                </div>
+                <h3>${project.title}</h3>
+                <p>${project.summary || ''}</p>
+                ${createTagList(project.tags)}
+                <span class="timeline-cta">View project</span>
               </div>
-              <h3>${project.title}</h3>
-              <p>${project.summary || ''}</p>
-              ${createTagList(project.tags)}
-              <span class="timeline-cta">View project</span>
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Summary
- display project preview images within the timeline cards for both collapsed and expanded states
- add styling hooks to support the new media block alongside existing copy
- document the required project metadata fields in a dedicated checklist for easy reference

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_690a10120abc832bb6c51b9f9d9ee6f0